### PR TITLE
Add Manual de Fraseologia Aeronáutica

### DIFF
--- a/docs/documentos/manual-fraseologia-aeronautica/.pages
+++ b/docs/documentos/manual-fraseologia-aeronautica/.pages
@@ -1,0 +1,10 @@
+title: Manual de Fraseologia Aeronáutica
+collapse: false
+children:
+  - index.pt.md
+  - conceituacao.pt.md
+  - alfabeto-fonetico.pt.md
+  - algarismos.pt.md
+  - exemplos-comunicacao.pt.md
+  - dicas.pt.md
+

--- a/docs/documentos/manual-fraseologia-aeronautica/.pages
+++ b/docs/documentos/manual-fraseologia-aeronautica/.pages
@@ -1,10 +1,10 @@
 title: Manual de Fraseologia Aeronáutica
 collapse: false
-children:
-  - index.pt.md
-  - conceituacao.pt.md
-  - alfabeto-fonetico.pt.md
-  - algarismos.pt.md
-  - exemplos-comunicacao.pt.md
-  - dicas.pt.md
+nav:
+  - Manual de Fraseologia Aeronáutica: index.pt.md
+  - Conceituação: conceituacao.pt.md
+  - Alfabeto Fonético: alfabeto-fonetico.pt.md
+  - Algarismos: algarismos.pt.md
+  - Exemplos de Comunicação: exemplos-comunicacao.pt.md
+  - Dicas Importantes: dicas.pt.md
 

--- a/docs/documentos/manual-fraseologia-aeronautica/alfabeto-fonetico.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/alfabeto-fonetico.pt.md
@@ -77,16 +77,18 @@ Quando for necessário soletrar, em radiotelefonia, nomes próprios, abreviatura
 <div class="page-navigation">
 
 <div class="nav-prev">
-<a href="conceituacao.pt.md">
+<a href="../conceituacao/">
 <span class="nav-arrow">←</span>
 <span class="nav-label">Página anterior</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Conceituação</span>
 </a>
 </div>
 
 <div class="nav-next">
-<a href="algarismos.pt.md">
+<a href="../algarismos/">
 <span class="nav-label">Próxima página</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Algarismos</span>
 <span class="nav-arrow">→</span>
 </a>

--- a/docs/documentos/manual-fraseologia-aeronautica/alfabeto-fonetico.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/alfabeto-fonetico.pt.md
@@ -15,31 +15,31 @@ Quando for necessário soletrar, em radiotelefonia, nomes próprios, abreviatura
 | Letra | Palavra | Convenção Fonética Internacional | Pronúncia |
 |:-----:|:-------:|:----------------------------------:|:----------:|
 | A | Alfa | 'ælfa | AL <u>FA</u> |
-| B | Bravo | 'bra:'vo | BRA <u>VOU</u> |
+| B | Bravo | 'braːvo | BRA <u>VOU</u> |
 | C | Charlie | 'tʃɑːli ou 'ʃɑːli | <u>CHAR</u> LI |
 | D | Delta | 'deltɑ | <u>DEL</u> TA |
 | E | Echo | 'eko | <u>E</u> COU |
 | F | Foxtrot | 'fɔkstrɔt | <u>FOX</u> TROT |
 | G | Golf | gʌlf | <u>GOLF</u> |
-| H | Hotel | ho:'tel | HOU <u>TEL</u> |
+| H | Hotel | hoː'tel | HOU <u>TEL</u> |
 | I | India | 'indi∙ɑ | <u>IN</u> DIA |
-| J | Juliett | 'dƷu:li∙'et | DJU <u>LIET</u> |
-| K | Kilo | 'ki:lo | <u>KI</u> LOU |
+| J | Juliett | 'dƷuːli∙'et | DJU <u>LIET</u> |
+| K | Kilo | 'kiːlo | <u>KI</u> LOU |
 | L | Lima | 'liːmɑ | <u>LI</u> MA |
 | M | Mike | mɑik | <u>MAIK</u> |
 | N | November | no'vembə | NO <u>VEM</u> BER |
 | O | Oscar | 'ɔskɑ | <u>OS</u> CAR |
 | P | Papa | pə'pɑ | <u>PA</u> PA |
 | Q | Quebec | ke'bek | QUE <u>BEC</u> |
-| R | Romeo | 'ro:mi∙o | ROU <u>MI</u> OU |
+| R | Romeo | 'roːmi∙o | ROU <u>MI</u> OU |
 | S | Sierra | si'erɑ | SI <u>E</u> RRA |
 | T | Tango | 'tængo | <u>TAN</u> GOU |
-| U | Uniform | 'ju:nifɔ:m ou 'u:nifɔrm | IU NI <u>FORM</u> |
+| U | Uniform | 'juːnifɔːm ou 'uːnifɔrm | IU NI <u>FORM</u> |
 | V | Victor | 'viktɑ | <u>VIC</u> TOR |
 | W | Whiskey | 'wiski | <u>UIS</u> QUI |
 | X | X-Ray | 'eks'rei | <u>EKS</u> REY |
 | Y | Yankee | 'jænki | <u>IAN</u> QUI |
-| Z | Zulu | 'zu:lu: | <u>ZU</u> LU |
+| Z | Zulu | 'zuːluː | <u>ZU</u> LU |
 
 ### Tabela 1 – Alfabeto fonético (Pronúncia em Espanhol)
 

--- a/docs/documentos/manual-fraseologia-aeronautica/alfabeto-fonetico.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/alfabeto-fonetico.pt.md
@@ -1,0 +1,96 @@
+---
+title: Alfabeto Fonético
+hide:
+  - toc
+---
+
+# Alfabeto Fonético
+
+## 2.5 Alfabeto Fonético
+
+Quando for necessário soletrar, em radiotelefonia, nomes próprios, abreviaturas de serviços e palavras de pronúncia duvidosa, usa-se o alfabeto fonético que se apresenta a seguir:
+
+### Tabela 1 – Alfabeto fonético
+
+| Letra | Palavra | Convenção Fonética Internacional | Pronúncia |
+|:-----:|:-------:|:----------------------------------:|:----------:|
+| A | Alfa | 'ælfa | AL <u>FA</u> |
+| B | Bravo | 'bra:'vo | BRA <u>VOU</u> |
+| C | Charlie | 'tʃɑːli ou 'ʃɑːli | <u>CHAR</u> LI |
+| D | Delta | 'deltɑ | <u>DEL</u> TA |
+| E | Echo | 'eko | <u>E</u> COU |
+| F | Foxtrot | 'fɔkstrɔt | <u>FOX</u> TROT |
+| G | Golf | gʌlf | <u>GOLF</u> |
+| H | Hotel | ho:'tel | HOU <u>TEL</u> |
+| I | India | 'indi∙ɑ | <u>IN</u> DIA |
+| J | Juliett | 'dƷu:li∙'et | DJU <u>LIET</u> |
+| K | Kilo | 'ki:lo | <u>KI</u> LOU |
+| L | Lima | 'liːmɑ | <u>LI</u> MA |
+| M | Mike | mɑik | <u>MAIK</u> |
+| N | November | no'vembə | NO <u>VEM</u> BER |
+| O | Oscar | 'ɔskɑ | <u>OS</u> CAR |
+| P | Papa | pə'pɑ | <u>PA</u> PA |
+| Q | Quebec | ke'bek | QUE <u>BEC</u> |
+| R | Romeo | 'ro:mi∙o | ROU <u>MI</u> OU |
+| S | Sierra | si'erɑ | SI <u>E</u> RRA |
+| T | Tango | 'tængo | <u>TAN</u> GOU |
+| U | Uniform | 'ju:nifɔ:m ou 'u:nifɔrm | IU NI <u>FORM</u> |
+| V | Victor | 'viktɑ | <u>VIC</u> TOR |
+| W | Whiskey | 'wiski | <u>UIS</u> QUI |
+| X | X-Ray | 'eks'rei | <u>EKS</u> REY |
+| Y | Yankee | 'jænki | <u>IAN</u> QUI |
+| Z | Zulu | 'zu:lu: | <u>ZU</u> LU |
+
+### Tabela 1 – Alfabeto fonético (Pronúncia em Espanhol)
+
+| Letra | Pronúncia em Espanhol |
+|:-----:|:---------------------:|
+| A | <u>A</u> |
+| B | <u>BÊ</u> |
+| C | <u>CÊ</u> |
+| D | <u>DÊ</u> |
+| E | <u>Ê</u> |
+| F | <u>É</u> <u>FE</u> |
+| G | <u>RÊ</u> |
+| H | <u>A</u> <u>TCHE</u> |
+| I | <u>I</u> |
+| J | <u>RRO</u> <u>TA</u> |
+| K | <u>KA</u> |
+| L | <u>É</u> <u>LE</u> |
+| M | <u>E</u> <u>ME</u> |
+| N | <u>E</u> <u>NE</u> |
+| O | <u>Ô</u> |
+| P | <u>PÊ</u> |
+| Q | <u>CU</u> |
+| R | <u>ÉR</u> <u>RE</u> |
+| S | <u>É</u> <u>SE</u> |
+| T | <u>TÊ</u> |
+| U | <u>U</u> |
+| V | <u>U</u> <u>BE</u> |
+| W | <u>U</u> <u>VE</u> <u>DO</u> <u>BLE</u> |
+| X | <u>É</u> <u>QUIS</u> |
+| Y | <u>IÊ</u> |
+| Z | <u>ZÊ</u> <u>TA</u> |
+
+---
+
+<div class="page-navigation">
+
+<div class="nav-prev">
+<a href="conceituacao.pt.md">
+<span class="nav-arrow">←</span>
+<span class="nav-label">Página anterior</span>
+<span class="nav-title">Conceituação</span>
+</a>
+</div>
+
+<div class="nav-next">
+<a href="algarismos.pt.md">
+<span class="nav-label">Próxima página</span>
+<span class="nav-title">Algarismos</span>
+<span class="nav-arrow">→</span>
+</a>
+</div>
+
+</div>
+

--- a/docs/documentos/manual-fraseologia-aeronautica/algarismos.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/algarismos.pt.md
@@ -1,0 +1,72 @@
+---
+title: Algarismos
+hide:
+  - toc
+---
+
+# Algarismos
+
+## Seção VII - Algarismos
+
+### Art. 23
+
+Todos os números devem ser transmitidos com a pronúncia de cada dígito separadamente, exceto nos casos previstos nos Art. 26, Art. 29 e Art. 32.
+
+### Tabela 2 – Algarismos
+
+| Numeral ou elemento numérico | Português | Pronúncia em inglês |
+|:----------------------------:|:---------:|:-------------------:|
+| 0 | ZE RO | <u>ZI ROU</u> |
+| 1 | UNO (UMA) | <u>UAN</u> |
+| 2 | DOIS (DUAS) | <u>TU</u> |
+| 3 | TRÊS | <u>TRI</u> |
+| 4 | QUA TRO | <u>FAU OR</u> |
+| 5 | CIN CO | <u>FA IF</u> |
+| 6 | MEIA | <u>SIKS</u> |
+| 7 | SE TE | <u>SE VEM</u> |
+| 8 | OI TO | <u>EIT</u> |
+| 9 | NO VE | <u>NAI NE</u> |
+| Decimal | DE CI MAL | <u>DEI CI MAL</u> |
+| 100 | - | <u>HAN DRED</u> |
+| 1.000 | MIL | <u>TAU ZAND</u> |
+
+### Tabela 2 – Algarismos (Pronúncia em Espanhol)
+
+| Algarismo | Pronúncia em Espanhol |
+|:---------:|:---------------------:|
+| 0 | C<u>E</u> RO |
+| 1 | <u>U</u> NO |
+| 2 | D<u>OS</u> |
+| 3 | TR<u>ES</u> |
+| 4 | CUA TR<u>O</u> |
+| 5 | C<u>IN</u> CO |
+| 6 | S<u>EIS</u> |
+| 7 | S<u>IE</u> TE |
+| 8 | <u>O</u> CHO |
+| 9 | N<u>UE</u> VE |
+| 10 | DIEZ |
+| Decimal | DECIM<u>AL</u> |
+| 1.000 | M<u>IL</u> |
+
+---
+
+<div class="page-navigation">
+
+<div class="nav-prev">
+<a href="alfabeto-fonetico.pt.md">
+<span class="nav-arrow">←</span>
+<span class="nav-label">Página anterior</span>
+<span class="nav-title">Alfabeto Fonético</span>
+</a>
+</div>
+
+<div class="nav-next">
+<a href="exemplos-comunicacao.pt.md">
+<span class="nav-label">Próxima página</span>
+<span class="nav-title">Exemplos de Comunicação</span>
+<span class="nav-arrow">→</span>
+</a>
+</div>
+
+</div>
+

--- a/docs/documentos/manual-fraseologia-aeronautica/algarismos.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/algarismos.pt.md
@@ -53,16 +53,18 @@ Todos os números devem ser transmitidos com a pronúncia de cada dígito separa
 <div class="page-navigation">
 
 <div class="nav-prev">
-<a href="alfabeto-fonetico.pt.md">
+<a href="../alfabeto-fonetico/">
 <span class="nav-arrow">←</span>
 <span class="nav-label">Página anterior</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Alfabeto Fonético</span>
 </a>
 </div>
 
 <div class="nav-next">
-<a href="exemplos-comunicacao.pt.md">
+<a href="../exemplos-comunicacao/">
 <span class="nav-label">Próxima página</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Exemplos de Comunicação</span>
 <span class="nav-arrow">→</span>
 </a>

--- a/docs/documentos/manual-fraseologia-aeronautica/conceituacao.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/conceituacao.pt.md
@@ -1,0 +1,87 @@
+---
+title: Conceituação
+hide:
+  - toc
+---
+
+# Conceituação
+
+## 2.1 Conceituação
+
+A fraseologia é um procedimento estabelecido com o objetivo de assegurar a uniformidade das comunicações radiotelefônicas, reduzir ao mínimo o tempo de transmissão das mensagens e proporcionar autorizações claras e concisas.
+
+!!! danger "Nota Importante"
+    No real os pilotos possuem uma coordenação com o controle com tranquilidade e sem atropelamento na fonia, no virtual evite ao máximo começar a chamar o controle quando o mesmo está em comunicação com outra aeronave, ou quando o controle passa uma informação e esta deve ser cotejada pela aeronave, aguarde seu cotejamento e inicie seu contato com o controle.
+
+## 2.2 Generalidades
+
+### 2.2.1 Complemento
+
+A fraseologia apresentada neste Manual não pretende ser completa. Quando for estritamente necessário, tanto os controladores de tráfego aéreo e operadores de estação aeronáutica como os pilotos poderão utilizar frases adicionais, devendo, no entanto, afastarem-se o mínimo possível da fraseologia.
+
+### 2.2.2 Princípios
+
+De acordo com as recomendações da OACI(Organização de Aviação Civil Internacional), na definição das palavras e expressões da fraseologia, foram adotados os seguintes princípios:
+
+a) utilizam-se palavras e expressões que possam garantir melhor compreensão nas transmissões radiotelefônicas;
+
+b) evitam-se palavras e expressões cujas pronúncias possam causar interpretações diversas; e
+
+c) na fraseologia inglesa, utilizam-se, preferencialmente, palavras de origem latina.
+
+### 2.3.7 O que se deve evitar
+
+Não devem ser utilizadas palavras que:
+
+a) em virtude de sua semelhança fonética, possam gerar confusão no entendimento. 
+
+**Exemplo:** Aguardar com decolar, hold com roll, afirmativo com negativo.
+
+b) sejam vazias de significado.
+
+**Exemplos:** Ok, ah, eé...
+
+### 2.3.8 Autorizações e Instruções
+
+O piloto em comando deverá cotejar (repetir) as seguintes autorizações e instruções transmitidas de forma oral, relacionadas à segurança:
+
+a) autorizações da rota ATC;
+
+b) autorizações e instruções para, em qualquer pista, efetuar entrada, pouso, decolagem, manter-se a certa distância, cruzar, taxiar e regressar; e
+
+c) pista em uso, ajuste de altímetro, código SSR, instruções de nível, instruções de proa e de velocidade e níveis de transição.
+
+!!! note "Nota"
+    Se um piloto repetir uma autorização ou instrução de maneira incorreta, o controlador transmitirá a palavra "negativo" seguida da versão correta.
+
+!!! tip "Dica"
+    Utilize "AFIRMO" ao invés de "AFIRMATIVO"
+
+!!! warning "Importante"
+    A fraseologia não deve ser utilizada com misturas de idiomas.
+
+
+
+
+---
+
+<div class="page-navigation">
+
+<div class="nav-prev">
+<a href="index.pt.md">
+<span class="nav-arrow">←</span>
+<span class="nav-label">Página anterior</span>
+<span class="nav-title">Início</span>
+</a>
+</div>
+
+<div class="nav-next">
+<a href="alfabeto-fonetico.pt.md">
+<span class="nav-label">Próxima página</span>
+<span class="nav-title">Alfabeto Fonético</span>
+<span class="nav-arrow">→</span>
+</a>
+</div>
+
+</div>
+

--- a/docs/documentos/manual-fraseologia-aeronautica/conceituacao.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/conceituacao.pt.md
@@ -68,16 +68,18 @@ c) pista em uso, ajuste de altímetro, código SSR, instruções de nível, inst
 <div class="page-navigation">
 
 <div class="nav-prev">
-<a href="index.pt.md">
+<a href="../">
 <span class="nav-arrow">←</span>
 <span class="nav-label">Página anterior</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Início</span>
 </a>
 </div>
 
 <div class="nav-next">
-<a href="alfabeto-fonetico.pt.md">
+<a href="../alfabeto-fonetico/">
 <span class="nav-label">Próxima página</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Alfabeto Fonético</span>
 <span class="nav-arrow">→</span>
 </a>

--- a/docs/documentos/manual-fraseologia-aeronautica/dicas.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/dicas.pt.md
@@ -1,0 +1,80 @@
+---
+title: Dicas Importantes
+hide:
+  - toc
+---
+
+# Dicas Importantes
+
+## Dicas para Controladores
+
+### 1. Encerramento de Serviço Radar
+
+Quando **NÃO HOUVER** controle adjacente para transferência do tráfego ou quando o Controle adjacente for Controle Convencional (Não radar), o correto é dizer:
+
+<div class="comms-block">
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GLO1419, serviço radar encerrado aos "XX", autorizado troca de frequência, UNO DOIS DOIS, decimal OITO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GLO1419, radar service terminated at "XX", frequency change approved, ONE TWO TWO, decimal EIGHT.
+</div>
+
+</div>
+
+### 2. Pronúncia da Palavra "VIA"
+!!! tip "Dica"
+    A palavra "VIA" no Português tanto no inglês Americano é pronunciada **"VIA"**, tal como é escrita.<br>
+    Já no inglês Europeu, é pronunciada **"VAIA"**, portanto, ambas estão corretas para o uso.
+
+### 3. Cotejamentos Completos
+
+Os cotejamentos e instruções passados pelo Órgão ATC, deverão ser feitos por completo.<br>
+A simples palavra **"CIENTE"** não é cotejamento.
+
+### 4. Termos a Evitar
+
+Termos como:
+
+- "Na caixa"
+- "Almas à bordo"
+- "CÂMBIO"
+
+Não devem ser utilizados pois não condizem informação correta na fraseologia aeronáutica
+e foram criados por pilotos que não levam a aviação à sério.
+
+!!! danger "ATENÇÃO"
+    Evitem seguir vícios de fraseologia por outros pilotos ou ouvindo escuta aérea real, podem haver termos que não são padronizados pela MCA-100-16. Qualquer dúvida, leia a MCA-100-16 FRASEOLOGIA DE TRÁFEGO AÉREO.
+
+## Notas Importantes
+
+### Não solicitar reporte desnecessário
+
+!!! important "Importante"
+    **NÃO É NECESSÁRIO** solicitar o reporte de "CALÇADO, SOLICITA CORTE E DESEMBARQUE" ou "PARA O CORTE E DESEMBARQUE".
+
+!!! warning "Importante"
+    SOMENTE é solicitado na aviação real em situações como exemplo de um aeródromo onde a torre não tenha contato visual por condições meteorológicas (neblina, cerração e chuva) com a aeronave no solo e solicita para a mesma informar apenas: **"AERONAVE CALÇADA"**
+
+### Manter na Escuta
+
+Caso você esteja controlando, **NÃO É NECESSÁRIO** solicitar que a aeronave mantenha na sua escuta até o corte.
+
+Evite termos desnecessários que fogem da fraseologia padrão, além de tornar a fraseologia mais agradável e objetiva, a fonia vai ficar mais limpa e dinâmica.
+
+---
+
+<div class="page-navigation">
+
+<div class="nav-prev">
+<a href="exemplos-comunicacao.pt.md">
+<span class="nav-arrow">←</span>
+<span class="nav-label">Página anterior</span>
+<span class="nav-title">Exemplos de Comunicação</span>
+</a>
+</div>
+
+</div>
+

--- a/docs/documentos/manual-fraseologia-aeronautica/dicas.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/dicas.pt.md
@@ -69,9 +69,10 @@ Evite termos desnecessários que fogem da fraseologia padrão, além de tornar a
 <div class="page-navigation">
 
 <div class="nav-prev">
-<a href="exemplos-comunicacao.pt.md">
+<a href="../exemplos-comunicacao/">
 <span class="nav-arrow">←</span>
 <span class="nav-label">Página anterior</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Exemplos de Comunicação</span>
 </a>
 </div>

--- a/docs/documentos/manual-fraseologia-aeronautica/exemplos-comunicacao.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/exemplos-comunicacao.pt.md
@@ -9,6 +9,7 @@ hide:
 ## Exemplos Práticos de Fraseologia
 
 ### Exemplo de Voo Completo
+
 Abaixo disponibilizamos um exemplo de voo completo, desde o contato inicial com o órgão de Tráfego (para autorização de plano), até o contato com o Solo no destino final em uma situação normal sem adversidades.
 
 #### 1. TRÁFEGO (DELIVERY)
@@ -78,7 +79,9 @@ GOL UNO CUATRO UNO NUEVE, llamará Rodaje Brasília en UNO DOS UNO, DECIMAL OCHO
 </div>
 
 #### 2. SOLO (Para acionamento, push back)
+
 ##### 2.1 SOLO (Acionamento e push back)
+
 <div class="comms-block">
 
 <div class="comms-pilot">
@@ -459,7 +462,6 @@ GOL ONE FOUR ONE NINE I will call São Paulo Control on ONE TWO NINE, decimal FO
 <strong>Piloto (Espanhol):</strong>
 GOL UNO CUATRO UNO NUEVE llamará Control São Paulo en UNO DOS NUEVE, decimal CUATRO CINCO.
 </div>
-<br>
 </div>
 
 #### 6. CONTROLE DE APROXIMAÇÃO
@@ -601,6 +603,7 @@ GOL UNO CUATRO UNO NUEVE pista UNO CERO DERECHA, aterrizaje autorizado.
 </div>
 
 ##### 7.1 TORRE DE CONTROLE (Transferência para o Solo)
+
 <div class="comms-block">
 
 <div class="comms-atc">

--- a/docs/documentos/manual-fraseologia-aeronautica/exemplos-comunicacao.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/exemplos-comunicacao.pt.md
@@ -1,0 +1,687 @@
+---
+title: Exemplos de Comunicação
+hide:
+  - toc
+---
+
+# Exemplos de Comunicação
+
+## Exemplos Práticos de Fraseologia
+
+### Exemplo de Voo Completo
+Abaixo disponibilizamos um exemplo de voo completo, desde o contato inicial com o órgão de Tráfego (para autorização de plano), até o contato com o Solo no destino final em uma situação normal sem adversidades.
+
+#### 1. TRÁFEGO (DELIVERY)
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Tráfego Brasília, GOL UNO QUATRO UNO NOVE, solicita autorização ATC, informação BRAVO.
+<br>
+
+<strong>Piloto (Inglês):</strong>
+Brasília Delivery, GOL ONE FOUR ONE NINE, request ATC clearance, information BRAVO.
+<br>
+
+<strong>Piloto (Espanhol):</strong>
+Tráfico Brasília, GOL UNO CUATRO UNO NUEVE, solicita autorización ATC, información BRAVO.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, autorizado até o aeroporto de Guarulhos; Rota do plano de voo, decola da pista DOIS NOVE ESQUERDA; Saída GAXO DOIS ALFA, transição ENRUR, Transponder 4035, Controle Brasília em UNO DOIS NOVE, DECIMAL UNO CINCO. Coteje. 
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE. Cleared to Guarulhos Airport, flight plan route, runway TWO NINE LEFT for departure; Climb via GAXO TWO ALFA, ENRUR transition; Squawk 4035, Brasília control on ONE TWO NINE, DECIMAL ONE FIVE, Read back. 
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, autorizado hasta el aeropuerto de Guarulhos; Ruta del plan de vuelo, despegue pista DOS NUEVE IZQUIERDA; Salida GAXO DOS ALFA, transición ENRUR, Transpondedor 4035, Control Brasília en UNO DOS NUEVE, DECIMAL UNO CINCO. Confirme.
+</div>
+<br>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE, autorizado até o aeroporto de Guarulhos; Rota do plano de voo, decola da pista DOIS NOVE ESQUERDA; Saída GAXO DOIS ALFA, transição ENRUR, Transponder 4035, Controle Brasília em UNO DOIS NOVE, DECIMAL UNO CINCO.
+<br>
+
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Cleared to Guarulhos Airport, flight plan route, runway TWO NINE LEFT for departure; Climb via GAXO TWO ALFA, ENRUR transition, squawk 4035, Brasília control on ONE TWO NINE, DECIMAL ONE FIVE. 
+<br>
+
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, autorizado hasta el aeropuerto de Guarulhos; Ruta del plan de vuelo, despegue pista DOS NUEVE IZQUIERDA; Salida GAXO DOS ALFA, transición ENRUR, Transpondedor 4035, Control Brasília en UNO DOS NUEVE, DECIMAL UNO CINCO.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, cotejamento correto, chame Solo Brasília em UNO DOIS UNO, DECIMAL OITO ZERO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE. your read back is correct, call Brasília Ground on ONE TWO ONE, DECIMAL EIGHT ZERO.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, confirmación correcta, llame Rodaje Brasília en UNO DOS UNO, DECIMAL OCHO CERO.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE, chamará o solo Brasília em UNO DOIS UNO, DECIMAL OITO ZERO.
+<br>
+
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, I will call Brasília Ground on ONE TWO ONE, DECIMAL EIGHT ZERO.
+<br>
+
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, llamará Rodaje Brasília en UNO DOS UNO, DECIMAL OCHO CERO.
+</div>
+</div>
+
+#### 2. SOLO (Para acionamento, push back)
+##### 2.1 SOLO (Acionamento e push back)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Solo Brasília, GOL UNO QUATRO UNO NOVE, posição pátio UNO, Box UNO QUATRO, pronto para acionamento e push back.
+<br>
+
+<strong>Piloto (Inglês):</strong>
+BRASÍLIA Ground, GOL ONE FOUR ONE NINE, position Box ONE FOUR, request start up and push back.
+<br>
+
+<strong>Piloto (Espanhol):</strong>
+Rodaje Brasília, GOL UNO CUATRO UNO NUEVE, posición plataforma UNO, Box UNO CUATRO, listo para arranque y retroceso.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, Solo Brasília, autorizado acionamento e push back, chame pronto para o táxi.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Brasília Ground, start up and push back approved, report ready for taxi.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, Rodaje Brasília, autorizado arranque y retroceso, llame listo para rodaje.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE, acionamento e push back aprovado, chamará pronto para o táxi.
+<br>
+
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, start up and push back approved, I will call when ready for taxi.
+<br>
+
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, arranque y retroceso aprobado, llamará listo para rodaje.
+</div>
+</div>
+
+##### 2.2 SOLO (Taxi)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE pronto para o táxi.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE ready for taxi.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE listo para rodaje.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, Solo Brasília, autorizado táxi autorizado para o ponto de espera pista DOIS NOVE ESQUERDA via taxiways LIMA QUATRO, KILO, UNIFORM e ZULU, ajuste de altímetro 1013.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Brasília Ground, taxi to holding point, runway TWO NINE LEFT, via taxiway LIMA FOUR, KILO, UNIFORM and ZULU, QNH ONE ZERO ONE THREE.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, Rodaje Brasília, autorizado rodaje al punto de espera pista DOS NUEVE IZQUIERDA vía calle de rodaje LIMA CUATRO, KILO, UNIFORM y ZULU, ajuste de altímetro 1013 (uno cero uno tres).
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE autorizado táxi autorizado para o ponto de espera pista DOIS NOVE ESQUERDA via taxiways LIMA QUATRO, KILO, UNIFORM e ZULU, ajuste de altímetro 1013.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE taxi to holding point, runway TWO NINE LEFT, via taxiway LIMA FOUR, KILO, UNIFORM and ZULU, QNH ONE ZERO ONE THREE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE autorizado rodaje al punto de espera pista DOS NUEVE IZQUIERDA vía calle de rodaje LIMA CUATRO, KILO, UNIFORM y ZULU, ajuste de altímetro 1013 (uno cero uno tres).
+</div>
+</div>
+
+##### 2.3 SOLO (Transferindo para a Torre)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Solo Brasília; GOL UNO QUATRO UNO NOVE no ponto de espera da pista DOIS NOVE ESQUERDA.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Ground, GOL ONE FOUR ONE NINE holding point runway TWO NINE LEFT.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Rodaje Brasília; GOL UNO CUATRO UNO NUEVE en el punto de espera pista DOS NUEVE IZQUIERDA.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, Solo Brasília, chame Torre Brasília em UNO UNO OITO, DECIMAL UNO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Brasília Ground, call Brasília Tower on ONE ONE EIGHT, DECIMAL ONE.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, Rodaje Brasília, llame Torre Brasília en UNO UNO OCHO, DECIMAL UNO.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE chamará Torre Brasília em UNO UNO OITO, DECIMAL UNO.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE I will call Brasília Tower on ONE ONE EIGHT, DECIMAL ONE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE llamará Torre Brasília en UNO UNO OCHO, DECIMAL UNO.
+</div>
+</div>
+
+#### 3. TORRE DE CONTROLE (Ingresso na pista e Decolagem)
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Torre Brasília; GOL UNO QUATRO UNO NOVE, ponto de espera pista DOIS NOVE ESQUERDA.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Tower; GOL ONE FOUR ONE NINE, holding point runway TWO NINE LEFT.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Torre Brasília; GOL UNO CUATRO UNO NUEVE, punto de espera pista DOS NUEVE IZQUIERDA.
+</div>
+
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE; Torre Brasília, pista DOIS NOVE ESQUERDA, autorizada decolagem, vento DOIS OITO ZERO GRAUS, ZERO NOVE NÓS.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Brasília Tower, runway TWO NINE LEFT, cleared for take-off, wind TWO EIGHT ZERO DEGREES, ZERO NINE KNOTS.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE; Torre Brasília, pista DOS NUEVE IZQUIERDA, autorizado despegue, viento DOS OCHO CERO grados, CERO NUEVE nudos.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE; pista DOIS NOVE ESQUERDA, autorizada decolagem.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE; runway TWO NINE LEFT, cleared for take-off.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE; pista DOS NUEVE IZQUIERDA, autorizado despegue.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE; decolado aos ZERO CINCO; chame o Controle Brasília em UNO UNO NOVE, DECIMAL DOIS.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE; airborne at ZERO FIVE, call Brasília Control on ONE ONE NINE, DECIMAL TWO.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE; en el aire a los CERO CINCO; llame el Control Brasília en UNO UNO NUEVE, DECIMAL DOS.
+</div>
+
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE; chamará Controle Brasília em UNO UNO NOVE, DECIMAL DOIS.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE; I will call Brasília Control on ONE ONE NINE, DECIMAL TWO.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE; llamará Control Brasília en UNO UNO NUEVE, DECIMAL DOS.
+</div>
+</div>
+
+#### 4. CONTROLE (Partida/Departure)
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Controle BRASÍLIA, GOL UNO QUATRO UNO NOVE, decolando pista DOIS NOVE ESQUERDA; passando CINCO MIL PÉS, saída GAXO DOIS ALFA, transição ENRUR.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Control, GOL ONE FOUR ONE NINE, airborne runway TWO NINE LEFT; passing FIVE THOUSAND FEET, GAXO TWO ALFA departure, ENRUR transition.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Control BRASÍLIA, GOL UNO CUATRO UNO NUEVE, despegando pista DOS NUEVE IZQUIERDA; pasando CINCO MIL pies, salida GAXO DOS ALFA, transición ENRUR.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE Controle Brasília ciente, contato radar na decolagem, suba via GAXO DOIS ALFA para o nível TRÊS MEIA ZERO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE Brasília Control roger, radar contact on departure, climb via GAXO TWO ALFA to flight level THREE SIX ZERO.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE Control Brasília recibido, contacto radar en el despegue, suba vía GAXO DOS ALFA hasta nivel TRES SEIS CERO.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE ciente, sobe via saída GAXO DOIS ALFA, para o nível TRÊS MEIA ZERO.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, roger, climb via GAXO TWO ALFA to flight level THREE SIX ZERO.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE recibido, sube vía salida GAXO DOS ALFA, hasta nivel TRES SEIS CERO.
+</div>
+</div>
+
+##### 4.1 CONTROLE (Transferindo para o Centro)
+<div class="comms-block">
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, chame Centro BRASÍLIA, UNO DOIS MEIA, decimal SETE CINCO;
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, call Brasília Center, UNE TWO SIX, decimal SEVEN FIVE;
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, llame Centro BRASÍLIA, UNO DOS SEIS, decimal SIETE CINCO;
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE, chamará Centro BRASÍLIA, UNO DOIS MEIA, decimal SETE CINCO;
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, I will call Brasília Center, UNE TWO SIX, decimal SEVEN FIVE;
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, llamará Centro BRASÍLIA, UNO DOS SEIS, decimal SIETE CINCO;
+</div>
+</div>
+
+#### 5. CENTRO (Subindo, cruzeiro e descida)
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Centro Brasília, GOL UNO QUATRO UNO NOVE.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Center, GOL ONE FOUR ONE NINE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Centro Brasília, GOL UNO CUATRO UNO NUEVE.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, Centro Brasília ciente, contato radar, suba e mantenha nível TRÊS MEIA ZERO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Brasília Center roger, radar contact, climb and maintain flight level THREE SIX ZERO.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, Centro Brasília recibido, contacto radar, suba y mantenga nivel TRES SEIS CERO.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE, ciente, sobe e mantém nível TRÊS MEIA ZERO.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, roger, climb and maintain flight level THREE SIX ZERO.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, recibido, sube y mantiene nivel TRES SEIS CERO.
+</div>
+</div>
+
+##### 4.1 CENTRO (Nivelando)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Centro Brasília, GOL UNO QUATRO UNO NOVE nível de voo TRÊS MEIA ZERO.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Center, GOL ONE FOUR ONE NINE reaching flight level THREE SIX ZERO.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Centro Brasília, GOL UNO CUATRO UNO NUEVE nivel de vuelo TRES SEIS CERO.
+</div>
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE Centro Brasília ciente, informe no ideal de descida.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE Brasília Center roger, inform when ready for descend.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE Centro Brasília recibido, informe cuando esté listo para descenso.
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE informará no ideal de descida.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE I will inform when ready for descend.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE informará cuando esté listo para descenso.
+</div>
+</div>
+
+##### 4.1 CENTRO (Ideal de descida)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Centro Brasília, GOL UNO QUATRO UNO NOVE no ponto ideal de descida.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Center, GOL ONE FOUR ONE NINE ready for descend.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Centro Brasília, GOL UNO CUATRO UNO NUEVE listo para descenso.
+</div>
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE Centro Brasília ciente, desça via SANPA UNO ALFA, reporte passando o nível UNO QUATRO CINCO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE Brasília Center roger, descent via SANPA UNO ALFA, report passing flight ONE FOUR FIVE.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE Centro Brasília recibido, descienda vía SANPA UNO ALFA, reporte pasando nivel UNO CUATRO CINCO.
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE ciente, desce via SANPA UNO ALFA, reportará passando o nível UNO QUATRO CINCO.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE roger, descent via SANPA UNO ALFA, I will report passing flight ONE FOUR FIVE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE recibido, desciende vía SANPA UNO ALFA, reportará pasando nivel UNO CUATRO CINCO.
+</div>
+</div>
+
+##### 4.2 CENTRO (Transferindo para o controle de aproximação)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Centro Brasília, GOL UNO QUATRO UNO NOVE passando o nível UNO QUATRO CINCO.
+<br>
+<strong>Piloto (Inglês):</strong>
+Brasília Center, GOL ONE FOUR ONE NINE passing flight level ONE FOUR FIVE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Centro Brasília, GOL UNO CUATRO UNO NUEVE pasando nivel UNO CUATRO CINCO.
+</div>
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, Centro Brasília ciente, chame agora o controle São Paulo em UNO DOIS NOVE, decimal QUATRO CINCO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, Brasília center roger, contact now São Paulo Control on ONE TWO NINE, decimal FOUR FIVE.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, Centro Brasília recibido, llame ahora el control São Paulo en UNO DOS NUEVE, decimal CUATRO CINCO.
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE chamará Controle São Paulo em UNO DOIS NOVE, decimal QUATRO CINCO.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE I will call São Paulo Control on ONE TWO NINE, decimal FOUR FIVE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE llamará Control São Paulo en UNO DOS NUEVE, decimal CUATRO CINCO.
+</div>
+<br>
+</div>
+
+#### 6. CONTROLE DE APROXIMAÇÃO
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Controle São Paulo, GOL UNO QUATRO UNO NOVE procedente de Brasília, passando nível UNO QUATRO CINCO para Guarulhos.
+<br>
+<strong>Piloto (Inglês):</strong>
+São Paulo Control, GOL ONE FOUR ONE NINE traffic from Brasília, passing flight level ONE FOUR FIVE to Guarulhos. 
+<br>
+<strong>Piloto (Espanhol):</strong>
+Control São Paulo, GOL UNO CUATRO UNO NUEVE procedente de Brasília, pasando nivel UNO CUATRO CINCO para Guarulhos.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE Controle São Paulo ciente, contato radar, desça via SANPA UNO ALFA, prevista aproximação ILS YANKEE para pista UNO ZERO DIREITA.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE São Paulo Control roger, radar contact, descend via SANPA UNO ALFA, expect ILS YANKEE approach for runway ONE ZERO RIGHT.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE Control São Paulo recibido, contacto radar, descienda vía SANPA UNO ALFA, prevista aproximación ILS YANKEE para pista UNO CERO DERECHA.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE Ciente, desce via SANPA UNO ALFA, prevista aproximação ILS YANKEE para pista UNO ZERO DIREITA.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE Roger, descend via SANPA ONE ALFA, expect ILS YANKEE approach for runway ONE ZERO RIGHT.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE Recibido, desciende vía SANPA UNO ALFA, prevista aproximación ILS YANKEE para pista UNO CERO DERECHA.
+</div>
+</div>
+
+##### 6.1 CONTROLE DE APROXIMAÇÃO (Autorização ILS)
+<div class="comms-block">
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE autorizado ILS YANKEE para pista UNO ZERO DIREITA, ajuste de altímetro (ou QNH) 1014, reporte estabilizado.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE cleared ILS YANKEE approach for runway ONE ZERO RIGHT, QNH ONE ZERO ONE FOUR, report established.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE autorizado ILS YANKEE para pista UNO CERO DERECHA, ajuste de altímetro (o QNH) 1014 (uno cero uno cuatro), reporte establecido.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE autorizado ILS YANKEE para pista UNO ZERO DIREITA, ajuste de altímetro (ou QNH) 1014, reportará estabilizado.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE cleared ILS YANKEE approach for runway ONE ZERO RIGHT, QNH ONE ZERO ONE FOUR, I will report established.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE autorizado ILS YANKEE para pista UNO CERO DERECHA, ajuste de altímetro (o QNH) 1014 (uno cero uno cuatro), reportará establecido.
+</div>
+</div>
+
+##### 6.2 CONTROLE DE APROXIMAÇÃO (Transferência para a Torre)
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong><br>
+Controle São Paulo, GOL UNO QUATRO UNO NOVE estabilizado no ILZ pista UNO ZERO DIREITA.
+
+<strong>Piloto (Inglês):</strong><br>
+São Paulo Control, GOL ONE FOUR ONE NINE established on ILS runway ONE ZERO RIGHT.
+
+<strong>Piloto (Espanhol):</strong><br>
+Control São Paulo, GOL UNO CUATRO UNO NUEVE establecido en ILS pista UNO CERO DERECHA.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE chame a Torre Guarulhos em UNO UNO OITO, decimal QUATRO.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE call Guarulhos Tower on ONE ONE EIGHT, decimal FOUR.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE llame la Torre Guarulhos en UNO UNO OCHO, decimal CUATRO.
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE chamará a Torre Guarulhos em UNO UNO OITO, decimal QUATRO.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE I will call Guarulhos Tower on ONE ONE EIGHT, decimal FOUR.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE llamará la Torre Guarulhos en UNO UNO OCHO, decimal CUATRO.
+</div>
+
+</div>
+
+#### 7. TORRE DE CONTROLE (Pouso)
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Torre Guarulhos, GOL UNO QUATRO UNO NOVE na final pista UNO ZERO DIREITA.
+<br>
+<strong>Piloto (Inglês):</strong>
+Guarulhos Tower, GOL ONE FOUR ONE NINE on final runway ONE ZERO RIGHT.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Torre Guarulhos, GOL UNO CUATRO UNO NUEVE en final pista UNO CERO DERECHA.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, pista UNO ZERO DIREITA, pouso autorizado, vento ZERO NOVE ZERO graus, ZERO OITO nós.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, runway ONE ZERO RIGHT, cleared to land, wind ZERO NINE ZERO degrees, ZERO EIGHT knots.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, pista UNO CERO DERECHA, aterrizaje autorizado, viento CERO NUEVE CERO grados, CERO OCHO nudos.
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE pista UNO ZERO DIREITA, pouso autorizado.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE runway ONE ZERO RIGHT, cleared to land.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE pista UNO CERO DERECHA, aterrizaje autorizado.
+</div>
+</div>
+
+##### 7.1 TORRE DE CONTROLE (Transferência para o Solo)
+<div class="comms-block">
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE, no solo aos FIVE ONE, livra na taxiway BRAVO BRAVO, autorizado cruzamento da pista UNO ZERO ESQUERDA, após livrar o cruzamento, chame o Solo Guarulhos em UNO DOIS NOVE, decimal SETE.
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE, on the ground at FIVE ONE, vacating runway on taxiway BRAVO BRAVO, cleared crossing runway ONE ZERO LEFT, after vacating runway contact Guarulhos Ground one UNO TWO ONE, decimal SEVEN.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, en tierra a los CINCO UNO, saliendo de pista en calle de rodaje BRAVO BRAVO, autorizado cruce de pista UNO CERO IZQUIERDA, después de salir del cruce, llame Rodaje Guarulhos en UNO DOS NUEVE, decimal SIETE.
+</div>
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE, livra na taxiway BRAVO BRAVO, autorizado cruzamento da pista UNO ZERO ESQUERDA, após livrar o cruzamento, chamará o Solo Guarulhos em UNO DOIS NOVE, decimal SETE.
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE, vacating runway on taxiway BRAVO BRAVO, cleared crossing runway ONE ZERO LEFT, after vacating runway I will contact Guarulhos Ground one UNO TWO ONE, decimal SEVEN.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE, saliendo de pista en calle de rodaje BRAVO BRAVO, autorizado cruce de pista UNO CERO IZQUIERDA, después de salir del cruce, llamará Rodaje Guarulhos en UNO DOS NUEVE, decimal SIETE.
+</div>
+</div>
+
+#### 8. SOLO (Após livrar a pista)
+
+<div class="comms-block">
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+Solo Guarulhos GOL UNO QUATRO UNO NOVE livrando a pista UNO ZERO ESQUERDA na interseção LIMA.
+<br>
+<strong>Piloto (Inglês):</strong>
+Guarulhos Ground, GOL ONE FOUR ONE NINE vacating runway, LIMA intersection.
+<br>
+<strong>Piloto (Espanhol):</strong>
+Rodaje Guarulhos GOL UNO CUATRO UNO NUEVE saliendo de pista UNO CERO IZQUIERDA en intersección LIMA.
+</div>
+
+<div class="comms-atc">
+<strong>Controlador (Português):</strong>
+GOL UNO QUATRO UNO NOVE autorizado táxi para o Pátio QUATRO via taxiway ALFA, INDIA, YANKEE QUATRO, YANKEE QUATRO WISKEY, posição QUATRO ZERO TRÊS. 
+<br>
+<strong>Controlador (Inglês):</strong>
+GOL ONE FOUR ONE NINE cleared taxi to appron FOUR, via taxiway ALFA, INDIA, YANKEE FOUR, YANKEE FOUR WISKEY, stand FOUR ZERO THREE.
+<br>
+<strong>Controlador (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE autorizado rodaje para Plataforma CUATRO vía calle de rodaje ALFA, INDIA, YANKEE CUATRO, YANKEE CUATRO WISKEY, posición CUATRO CERO TRES.
+</div>
+
+<div class="comms-pilot">
+<strong>Piloto (Português):</strong>
+GOL UNO QUATRO UNO NOVE ciente, autorizado táxi para o Pátio QUATRO via taxiway ALFA, INDIA, YANKEE QUATRO, YANKEE QUATRO WISKEY, posição QUATRO ZERO TRÊS. 
+<br>
+<strong>Piloto (Inglês):</strong>
+GOL ONE FOUR ONE NINE roger, cleared taxi to appron FOUR, via taxiway ALFA, INDIA, YANKEE FOUR, YANKEE FOUR WISKEY, stand FOUR ZERO THREE.
+<br>
+<strong>Piloto (Espanhol):</strong>
+GOL UNO CUATRO UNO NUEVE recibido, autorizado rodaje para Plataforma CUATRO vía calle de rodaje ALFA, INDIA, YANKEE CUATRO, YANKEE CUATRO WISKEY, posición CUATRO CERO TRES.
+</div>
+</div>
+
+---
+
+<div class="page-navigation">
+
+<div class="nav-prev">
+<a href="algarismos.pt.md">
+<span class="nav-arrow">←</span>
+<span class="nav-label">Página anterior</span>
+<span class="nav-title">Algarismos</span>
+</a>
+</div>
+
+<div class="nav-next">
+<a href="dicas.pt.md">
+<span class="nav-label">Próxima página</span>
+<span class="nav-title">Dicas</span>
+<span class="nav-arrow">→</span>
+</a>
+</div>
+
+</div>
+

--- a/docs/documentos/manual-fraseologia-aeronautica/exemplos-comunicacao.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/exemplos-comunicacao.pt.md
@@ -668,16 +668,18 @@ GOL UNO CUATRO UNO NUEVE recibido, autorizado rodaje para Plataforma CUATRO vía
 <div class="page-navigation">
 
 <div class="nav-prev">
-<a href="algarismos.pt.md">
+<a href="../algarismos/">
 <span class="nav-arrow">←</span>
 <span class="nav-label">Página anterior</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Algarismos</span>
 </a>
 </div>
 
 <div class="nav-next">
-<a href="dicas.pt.md">
+<a href="../dicas/">
 <span class="nav-label">Próxima página</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Dicas</span>
 <span class="nav-arrow">→</span>
 </a>

--- a/docs/documentos/manual-fraseologia-aeronautica/index.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/index.pt.md
@@ -1,0 +1,57 @@
+---
+title: Manual de Fraseologia Aeronáutica
+hide:
+  - toc
+---
+
+# Manual de Fraseologia Aeronáutica
+
+## Apresentação
+
+Bem-vindo ao Manual de Fraseologia Aeronáutica, um guia prático e objetivo desenvolvido para auxiliar profissionais da aviação e entusiastas na comunicação radiotelefônica padronizada.
+Este manual foi elaborado com foco na clareza e objetividade, apresentando os padrões estabelecidos pelas normas brasileiras e internacionais de fraseologia aeronáutica.
+
+**ATUALIZAÇÃO 12/2025**
+
+## Sobre este Manual
+
+Após a leitura deste manual, perceberá que a fraseologia ficou mais enxuta e mais clara, consequentemente mais objetiva.
+
+Este manual foi criado de acordo com os tópicos relacionados no **MCA-100-16** (FRASEOLOGIA DE TRÁFEGO AÉREO)
+
+É importantíssimo a leitura constante do MCA-100-16, o mesmo se encontra no site do DECEA através do link abaixo:
+
+### MCA 100-16 - Fraseologia de Tráfego Aéreo
+
+Estabelece os padrões de fraseologia de tráfego aéreo, em complemento ao disposto na **ICA-100-12**, "Regras do Ar".
+**Publicado no BCA n° 206, de 14 de novembro de 2024**
+MCA-100-16 [Link para publicação](https://publicacoes.decea.mil.br/publicacao/MCA-100-16)
+
+### MCA 100-21 - Fraseologia de Tráfego Aéreo em Espanhol
+Este manual também adiciona como exemplo, a fraseologia padrão em espanhol em complemento ao disposto na **MCA-100-21**, Fraseologia de Tráfego Aéreo em Espanhol
+**PORTARIA DECEA/DNOR N° 1.907, DE 13 DE OUTUBRO DE 2025.**
+MCA-100-21 [Link para publicação](https://publicacoes.decea.mil.br/publicacao/MCA-100-21)
+
+
+## Escopo
+
+A fraseologia contida aqui refere-se apenas ao básico de um voo instrumentos sem situações adversas, que caso ocorram devem procurar na MCA-100-16.
+
+---
+
+## Conhecimento não ocupa espaço
+
+---
+
+<div class="page-navigation">
+
+<div class="nav-next">
+<a href="conceituacao.pt.md">
+<span class="nav-label">Próxima página</span>
+<span class="nav-title">Conceituação</span>
+<span class="nav-arrow">→</span>
+</a>
+</div>
+
+</div>
+

--- a/docs/documentos/manual-fraseologia-aeronautica/index.pt.md
+++ b/docs/documentos/manual-fraseologia-aeronautica/index.pt.md
@@ -2,18 +2,20 @@
 title: Manual de Fraseologia Aeronáutica
 hide:
   - toc
+toc:
+  depth: 0
 ---
 
 # Manual de Fraseologia Aeronáutica
 
-## Apresentação
+### Apresentação
 
 Bem-vindo ao Manual de Fraseologia Aeronáutica, um guia prático e objetivo desenvolvido para auxiliar profissionais da aviação e entusiastas na comunicação radiotelefônica padronizada.
 Este manual foi elaborado com foco na clareza e objetividade, apresentando os padrões estabelecidos pelas normas brasileiras e internacionais de fraseologia aeronáutica.
 
 **ATUALIZAÇÃO 12/2025**
 
-## Sobre este Manual
+### Sobre este Manual
 
 Após a leitura deste manual, perceberá que a fraseologia ficou mais enxuta e mais clara, consequentemente mais objetiva.
 
@@ -33,21 +35,22 @@ Este manual também adiciona como exemplo, a fraseologia padrão em espanhol em 
 MCA-100-21 [Link para publicação](https://publicacoes.decea.mil.br/publicacao/MCA-100-21)
 
 
-## Escopo
+### Escopo
 
 A fraseologia contida aqui refere-se apenas ao básico de um voo instrumentos sem situações adversas, que caso ocorram devem procurar na MCA-100-16.
 
 ---
 
-## Conhecimento não ocupa espaço
+### Conhecimento não ocupa espaço
 
 ---
 
 <div class="page-navigation">
 
 <div class="nav-next">
-<a href="conceituacao.pt.md">
+<a href="conceituacao/">
 <span class="nav-label">Próxima página</span>
+<span class="nav-separator">|</span>
 <span class="nav-title">Conceituação</span>
 <span class="nav-arrow">→</span>
 </a>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -55,7 +55,24 @@
 .md-typeset table td {
     border-left: 1px solid rgba(0, 0, 0, 0.12);
     border-right: 1px solid rgba(0, 0, 0, 0.12);
-    padding: 0.5rem 1rem;
+    padding: 0.75rem 1.25rem;
+    font-size: 0.9375rem;
+}
+
+/* Tabelas maiores para melhor legibilidade - target tables after h3 headings */
+.md-typeset h3 + table {
+    width: 100%;
+}
+
+.md-typeset h3 + table th,
+.md-typeset h3 + table td {
+    padding: 1rem 1.5rem !important;
+    font-size: 1rem !important;
+}
+
+.md-typeset h3 + table th {
+    font-size: 1.0625rem !important;
+    font-weight: 600;
 }
 
 .md-typeset table th:first-child,
@@ -192,8 +209,16 @@
     flex-direction: row;
 }
 
-.nav-next a .nav-label {
+.nav-prev a .nav-label {
     margin-right: 0.5rem;
+}
+
+.nav-prev a .nav-separator {
+    margin: 0 0.5rem;
+}
+
+.nav-next a .nav-label {
+    margin-right: 0;
 }
 
 .nav-next a .nav-separator {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -10,3 +10,288 @@
 .corVatbrzVerde { color: #5cbd9e; }
 .corVatbrzCiano { color: #3db2ff; }
 .corVatbrzVerdeMusgo { color: #52a77e; }
+
+/* Estilo personalizado para Nota Importante - Fundo vermelho e texto branco */
+.md-typeset .admonition.danger {
+    background-color: #d32f2f !important;
+    border-color: #b71c1c !important;
+    color: #ffffff !important;
+}
+
+.md-typeset .admonition.danger .admonition-title {
+    background-color: #b71c1c !important;
+    color: #ffffff !important;
+    border-color: #b71c1c !important;
+}
+
+.md-typeset .admonition.danger .admonition-title::before {
+    color: #ffffff !important;
+}
+
+.md-typeset .admonition.danger p,
+.md-typeset .admonition.danger li,
+.md-typeset .admonition.danger code,
+.md-typeset .admonition.danger strong,
+.md-typeset .admonition.danger em {
+    color: #ffffff !important;
+}
+
+/* Garantir que links dentro do admonition também sejam brancos */
+.md-typeset .admonition.danger a {
+    color: #ffffff !important;
+    text-decoration: underline;
+}
+
+.md-typeset .admonition.danger a:hover {
+    color: #f5f5f5 !important;
+}
+
+/* Estilos para tabelas - linhas visíveis entre colunas */
+.md-typeset table {
+    border-collapse: collapse;
+}
+
+.md-typeset table th,
+.md-typeset table td {
+    border-left: 1px solid rgba(0, 0, 0, 0.12);
+    border-right: 1px solid rgba(0, 0, 0, 0.12);
+    padding: 0.5rem 1rem;
+}
+
+.md-typeset table th:first-child,
+.md-typeset table td:first-child {
+    border-left: none;
+}
+
+.md-typeset table th:last-child,
+.md-typeset table td:last-child {
+    border-right: none;
+}
+
+/* Para modo escuro */
+[data-md-color-scheme="slate"] .md-typeset table th,
+[data-md-color-scheme="slate"] .md-typeset table td {
+    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-right: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/* Linhas alternadas (zebra striping) para tabelas */
+.md-typeset table tbody tr:nth-child(even) {
+    background-color: rgba(0, 0, 0, 0.03);
+}
+
+[data-md-color-scheme="slate"] .md-typeset table tbody tr:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.03);
+}
+
+/* Estilo para sublinhado nas tabelas */
+.md-typeset table u {
+    text-decoration: underline;
+    text-decoration-thickness: 1.5px;
+    text-underline-offset: 2px;
+}
+
+/* Estilos para blocos de comunicação */
+.comms-block {
+    margin: 1.5rem 0;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.comms-pilot {
+    background-color: #e8f5e9;
+    padding: 1rem 1.25rem;
+    border-left: 4px solid #4caf50;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.comms-atc {
+    background-color: #e3f2fd;
+    padding: 1rem 1.25rem;
+    border-left: 4px solid #2196f3;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+.comms-pilot strong,
+.comms-atc strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: #333;
+}
+
+.comms-pilot br + strong {
+    margin-top: 1rem;
+}
+
+.comms-atc br + strong {
+    margin-top: 1rem;
+}
+
+/* Para modo escuro */
+[data-md-color-scheme="slate"] .comms-pilot {
+    background-color: rgba(76, 175, 80, 0.15);
+    border-left-color: #4caf50;
+}
+
+[data-md-color-scheme="slate"] .comms-atc {
+    background-color: rgba(33, 150, 243, 0.15);
+    border-left-color: #2196f3;
+}
+
+[data-md-color-scheme="slate"] .comms-pilot strong,
+[data-md-color-scheme="slate"] .comms-atc strong {
+    color: #e0e0e0;
+}
+
+/* Estilos para navegação de páginas */
+.page-navigation {
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    flex-wrap: wrap;
+    gap: 2rem;
+}
+
+.nav-prev,
+.nav-next {
+    flex: 1;
+    min-width: 150px;
+}
+
+.nav-prev a,
+.nav-next a {
+    display: flex;
+    align-items: center;
+    padding: 0.625rem 1rem;
+    background-color: #f5f5f5;
+    color: #333 !important;
+    text-decoration: none;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    min-height: 40px;
+    font-size: 0.875rem;
+}
+
+.nav-prev a {
+    justify-content: flex-start;
+    flex-direction: row;
+}
+
+.nav-next a {
+    justify-content: flex-end;
+    flex-direction: row;
+}
+
+.nav-next a .nav-label {
+    margin-right: 0.5rem;
+}
+
+.nav-next a .nav-separator {
+    margin: 0 0.5rem;
+}
+
+.nav-next a .nav-arrow {
+    margin-left: 0.5rem;
+    margin-right: 0;
+}
+
+.nav-prev a:hover,
+.nav-next a:hover {
+    background-color: #2196f3;
+    color: #ffffff !important;
+    border-color: #2196f3;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(33, 150, 243, 0.3);
+}
+
+.nav-prev a:active,
+.nav-next a:active {
+    transform: translateY(0);
+}
+
+.nav-arrow {
+    font-size: 1rem;
+    font-weight: bold;
+    margin: 0 0.5rem;
+    color: inherit;
+    flex-shrink: 0;
+}
+
+.nav-label {
+    display: inline;
+    font-size: 0.75rem;
+    opacity: 0.7;
+    font-weight: normal;
+    line-height: 1.2;
+    letter-spacing: 0.02em;
+    word-spacing: 0.1em;
+    margin-right: 0.5rem;
+}
+
+.nav-separator {
+    display: inline;
+    margin: 0 0.5rem;
+    opacity: 0.4;
+    color: inherit;
+    font-weight: normal;
+}
+
+.nav-title {
+    display: inline;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: inherit;
+    line-height: 1.3;
+}
+
+.nav-prev a:hover .nav-label,
+.nav-next a:hover .nav-label {
+    opacity: 0.9;
+}
+
+/* Para modo escuro */
+[data-md-color-scheme="slate"] .page-navigation {
+    border-top-color: rgba(255, 255, 255, 0.12);
+}
+
+[data-md-color-scheme="slate"] .nav-prev a,
+[data-md-color-scheme="slate"] .nav-next a {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: #e0e0e0 !important;
+}
+
+[data-md-color-scheme="slate"] .nav-prev a:hover,
+[data-md-color-scheme="slate"] .nav-next a:hover {
+    background-color: #1976d2;
+    border-color: #1976d2;
+    color: #ffffff !important;
+}
+
+/* Responsividade */
+@media (max-width: 768px) {
+    .page-navigation {
+        flex-direction: column;
+    }
+    
+    .nav-prev,
+    .nav-next {
+        width: 100%;
+    }
+    
+    .nav-prev a,
+    .nav-next a {
+        width: 100%;
+        justify-content: space-between;
+    }
+}


### PR DESCRIPTION
# feat: Add Manual de Fraseologia Aeronáutica document

## Summary
This PR adds a comprehensive multi-page "Manual de Fraseologia Aeronáutica" document to the documentation site, integrating content from the external documentation repository and implementing custom styling for improved readability and navigation.

## Changes

### 📚 New Documentation
- Added **Manual de Fraseologia Aeronáutica** as a new section under "Documentos"
- Integrated 6-page document structure:
  - **Apresentação** (`index.pt.md`) - Introduction and overview
  - **Conceituação** (`conceituacao.pt.md`) - Concepts and definitions
  - **Alfabeto Fonético** (`alfabeto-fonetico.pt.md`) - Phonetic alphabet tables
  - **Algarismos** (`algarismos.pt.md`) - Numbers and numerals
  - **Exemplos de Comunicação** (`exemplos-comunicacao.pt.md`) - Communication examples
  - **Dicas Importantes** (`dicas.pt.md`) - Important tips

### 🎨 Styling Improvements
- **Custom CSS enhancements** (`docs/stylesheets/extra.css`):
  - Custom page navigation buttons with improved spacing and separators
  - Enhanced table styling for better readability (increased padding and font sizes)
  - Responsive design with dark mode support
  - Improved visual hierarchy for navigation elements

### 🔧 Navigation Fixes
- Fixed navigation order using `.pages` configuration file
- Corrected internal navigation links to prevent 404 errors
- Implemented proper relative path resolution for sibling pages
- Added custom page navigation blocks with "Página anterior" and "Próxima página" buttons
- Fixed navigation button styling with proper margins and separators (`|`)

### 🐛 Bug Fixes
- Fixed IPA notation in phonetic alphabet table (replaced colons with long vowel marks to prevent emoji rendering)
- Resolved table rendering issues by removing incorrect HTML wrappers
- Fixed table sizing and alignment for better readability
- Corrected navigation link paths to work with i18n plugin structure

## Technical Details

### File Structure
```
docs/documentos/manual-fraseologia-aeronautica/
├── .pages                    # Navigation configuration
├── index.pt.md              # Main introduction page
├── conceituacao.pt.md       # Concepts section
├── alfabeto-fonetico.pt.md  # Phonetic alphabet tables
├── algarismos.pt.md         # Numbers section
├── exemplos-comunicacao.pt.md # Communication examples
└── dicas.pt.md              # Tips section
```

### Key Features
- **i18n Support**: All files follow the `.pt.md` naming convention for Portuguese content
- **Navigation Control**: Uses `awesome-pages` plugin for explicit navigation ordering
- **Custom Styling**: Enhanced CSS for tables, navigation buttons, and page layout
- **Responsive Design**: Works seamlessly on desktop and mobile devices
- **Dark Mode**: Full support for Material for MkDocs dark theme

## Testing
- ✅ Verified all navigation links work correctly
- ✅ Confirmed table rendering and styling
- ✅ Tested navigation button spacing and separators
- ✅ Validated IPA notation displays correctly (no emoji flags)
- ✅ Checked responsive behavior on different screen sizes

## Related
- Based on content from `/Users/tavares/orustechnology/projects/vatbrz/docs`
- Follows MCA-100-16 (FRASEOLOGIA DE TRÁFEGO AÉREO) standards
- References MCA-100-21 (Fraseologia de Tráfego Aéreo em Espanhol)

## Screenshots
- Navigation buttons with proper spacing and separators
- Enhanced table styling for phonetic alphabet
- Multi-page document structure in sidebar navigation

---

**Files Changed**: 11 files
- 7 new documentation files
- 1 navigation configuration file (`.pages`)
- 1 CSS stylesheet (enhanced with 300+ lines)